### PR TITLE
don't access request.body, use request.POST instead

### DIFF
--- a/elk-django/formatter.py
+++ b/elk-django/formatter.py
@@ -23,11 +23,9 @@ class LogstashFormatter(LogstashFormatterVersion1):
             message['request_method'] = request.method
             message['request_url'] = str(request.build_absolute_uri())
             try:
-                message['request_body'] = json.loads(request.body) if request.body else ''
+                message['request_body'] = json.loads(request.body)
             except:
-                message['request_body'] = ''
-
-            message['request_body'] = str(request.body)
+                message['request_body'] = str(request.body)
             message['request_get_query'] = str(request.GET)
 
             message['user-agent'] = request.META.get('HTTP_USER_AGENT')
@@ -38,7 +36,7 @@ class LogstashFormatter(LogstashFormatterVersion1):
                 message['user.username'] = str(user)
                 message['user.id'] = getattr(user, 'id', None)
                 message['user.email'] = getattr(user, 'email', None)
-                message['user.is_anonymus'] = getattr(user, 'is_anonymous', None)
+                message['user.is_anonymous'] = getattr(user, 'is_anonymous', None)
 
         message.update(self.get_extra_fields(record))
 

--- a/elk-django/middleware.py
+++ b/elk-django/middleware.py
@@ -7,12 +7,6 @@ request_logger = logging.getLogger('django.request')
 
 
 class LoggingMiddleware(MiddlewareMixin):
-
-    _initial_http_body = None
-
-    def process_request(self, request):
-        self._initial_http_body = request.body
-
     def process_response(self, request, response):
         """
         Adding request and response INFO logging


### PR DESCRIPTION
Accessing request.body includes reading the FILES submitted, which fails the DATA_UPLOAD_MAX_MEMORY_SIZE check. Increasing DATA_UPLOAD_MAX_MEMORY_SIZE is not a solution, since these files should not be loaded in memory and the default value of 2.5MB is reasonable.
Use request.POST to obtain the data instead.